### PR TITLE
Bug 1152392 - use quitter to shutdown the webapp, r=snorp.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,15 @@
             text-align: center;
         }
     </style>
+    <script>
+    function quit() {
+      var evt = document.createEvent('Events');
+      evt.initEvent('please-quit', true, false);
+      document.dispatchEvent(evt);
+    }
+    window.addEventListener("load", function () { setTimeout(quit, 1000); }, false);
+    window.onerror = quit;
+    </script>
     </head>
     <body>
 


### PR DESCRIPTION
This adds a call to Quitter to shut down the app when the index.html completes loading. This is temporary until we get the new mozilla-central based quitter@mozilla.com.xpi updated and signed, but it is something I want to make available as soon as possible.
